### PR TITLE
Feat/fe-add-cookie-modal

### DIFF
--- a/src/components/Cookie/Cookie.tsx
+++ b/src/components/Cookie/Cookie.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { FC, useState, useEffect } from 'react';
+import { InfoModal } from '@/components/InfoModal';
+import {
+  COOKIE_MODAL_ID,
+  CookieModalContent,
+} from '@/components/Cookie/CookieModalContent';
+
+const COOKIE_CONSENT_KEY = 'cookieConsent';
+
+export const Cookie: FC = () => {
+  const [isModalOpen, setModalOpen] = useState(false);
+
+  useEffect(() => {
+    const hasConsent = localStorage.getItem(COOKIE_CONSENT_KEY);
+    if (!hasConsent) {
+      setModalOpen(true);
+    }
+  }, []);
+
+  const handleCloseModal = () => {
+    localStorage.setItem(COOKIE_CONSENT_KEY, 'true');
+    setModalOpen(false);
+  };
+
+  return (
+    <>
+      {isModalOpen && (
+        <InfoModal
+          minWidth="275"
+          hideBackdrop
+          open={isModalOpen}
+          aria-describedby={COOKIE_MODAL_ID}
+          onClose={handleCloseModal}
+          sx={{
+            display: 'flex',
+            p: 1,
+            alignItems: 'center',
+            justifyContent: 'end',
+          }}
+        >
+          <>
+            <CookieModalContent onClose={handleCloseModal} />
+          </>
+        </InfoModal>
+      )}
+    </>
+  );
+};

--- a/src/components/Cookie/Cookie.tsx
+++ b/src/components/Cookie/Cookie.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { FC, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { InfoModal } from '@/components/InfoModal';
 import {
   COOKIE_MODAL_ID,
-  CookieModalContent,
+  CookieContent,
 } from '@/components/Cookie/CookieModalContent';
 
 const COOKIE_CONSENT_KEY = 'cookieConsent';
 
-export const Cookie: FC = () => {
+export const Cookie = () => {
   const [isModalOpen, setModalOpen] = useState(false);
 
   useEffect(() => {
@@ -25,26 +25,23 @@ export const Cookie: FC = () => {
   };
 
   return (
-    <>
-      {isModalOpen && (
-        <InfoModal
-          minWidth="275"
-          hideBackdrop
-          open={isModalOpen}
-          aria-describedby={COOKIE_MODAL_ID}
-          onClose={handleCloseModal}
-          sx={{
-            display: 'flex',
-            p: 1,
-            alignItems: 'center',
-            justifyContent: 'end',
-          }}
-        >
-          <>
-            <CookieModalContent onClose={handleCloseModal} />
-          </>
-        </InfoModal>
-      )}
-    </>
+    isModalOpen && (
+      <InfoModal
+        minWidth="275"
+        hideBackdrop
+        open={isModalOpen}
+        aria-describedby={COOKIE_MODAL_ID}
+        sx={{
+          display: 'flex',
+          p: 1,
+          alignItems: 'center',
+          justifyContent: 'end',
+        }}
+      >
+        <>
+          <CookieContent onClose={handleCloseModal} />
+        </>
+      </InfoModal>
+    )
   );
 };

--- a/src/components/Cookie/CookieModalContent.tsx
+++ b/src/components/Cookie/CookieModalContent.tsx
@@ -1,0 +1,46 @@
+import { forwardRef } from 'react';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+export const COOKIE_MODAL_ID = 'server-modal-description';
+
+type CookieModalContentProps = {
+  onClose: () => void;
+};
+
+export const CookieModalContent = forwardRef<
+  HTMLDivElement,
+  CookieModalContentProps
+>(function CookieModalContent({ onClose }, ref) {
+  const handleOkayClick = () => {
+    onClose();
+  };
+
+  return (
+    <div ref={ref}>
+      <Stack
+        sx={{
+          position: 'relative',
+          maxWidth: 275,
+          bgcolor: 'secondary.contrastText',
+          p: 2,
+        }}
+      >
+        <Typography
+          id="COOKIE_MODAL_ID"
+          variant="caption"
+          color="black.main"
+          sx={{ pt: 1, pb: 2 }}
+        >
+          Мы используем файлы cookie, чтобы вам было удобнее пользоваться нашим
+          сайтом. Продолжая пользоваться сайтом, вы соглашаетесь с
+          использованием нами файлов cookies.
+        </Typography>
+        <Button variant="contained" color="secondary" onClick={handleOkayClick}>
+          Хорошо
+        </Button>
+      </Stack>
+    </div>
+  );
+});

--- a/src/components/Cookie/CookieModalContent.tsx
+++ b/src/components/Cookie/CookieModalContent.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, Ref } from 'react';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -9,10 +9,10 @@ type CookieModalContentProps = {
   onClose: () => void;
 };
 
-export const CookieModalContent = forwardRef<
-  HTMLDivElement,
-  CookieModalContentProps
->(function CookieModalContent({ onClose }, ref) {
+const CookieModalContent = (
+  { onClose }: CookieModalContentProps,
+  ref: Ref<HTMLInputElement>,
+) => {
   const handleOkayClick = () => {
     onClose();
   };
@@ -37,10 +37,17 @@ export const CookieModalContent = forwardRef<
           сайтом. Продолжая пользоваться сайтом, вы соглашаетесь с
           использованием нами файлов cookies.
         </Typography>
-        <Button variant="contained" color="secondary" onClick={handleOkayClick}>
-          Хорошо
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={handleOkayClick}
+          sx={{ borderRadius: 0 }}
+        >
+          xорошо
         </Button>
       </Stack>
     </div>
   );
-});
+};
+
+export const CookieContent = forwardRef(CookieModalContent);

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { FC, ReactNode, useRef } from 'react';
+import Modal, { ModalProps } from '@mui/material/Modal';
+import Box from '@mui/material/Box';
+
+type CookieModalProps = ModalProps & {
+  children: ReactNode;
+  minWidth: string;
+};
+
+export const InfoModal: FC<CookieModalProps> = ({
+  children,
+  minWidth,
+  ...props
+}) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <Box
+      sx={{
+        minWidth: minWidth,
+        transform: 'translateZ(0)',
+        '@media all and (-ms-high-contrast: none)': {
+          display: 'none',
+        },
+      }}
+      ref={rootRef}
+    >
+      <Modal
+        disableEnforceFocus
+        disableAutoFocus
+        container={() => rootRef.current}
+        {...props}
+      >
+        {children}
+      </Modal>
+    </Box>
+  );
+};

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -20,7 +20,6 @@ export const InfoModal: FC<CookieModalProps> = ({
     <Box
       sx={{
         minWidth: minWidth,
-        transform: 'translateZ(0)',
         '@media all and (-ms-high-contrast: none)': {
           display: 'none',
         },

--- a/src/components/Input/classNameConstants.ts
+++ b/src/components/Input/classNameConstants.ts
@@ -6,11 +6,12 @@ export const CLASS_NAMES_INPUT = {
   grey: 'subvariant-grey',
 } as const;
 
-export const CLASS_MANES_LABEL = {
+// TODO: FIX TYPO
+export const CLASS_NAMES_LABEL = {
   start: 'subvariant-start',
   end: 'subvariant-end',
 } as const;
 
 export type InputVariant = ObjectValues<typeof CLASS_NAMES_INPUT>;
 
-export type LabelVariant = ObjectValues<typeof CLASS_MANES_LABEL>;
+export type LabelVariant = ObjectValues<typeof CLASS_NAMES_LABEL>;

--- a/src/mui/DevPage.tsx
+++ b/src/mui/DevPage.tsx
@@ -12,7 +12,7 @@ import { InputPassword } from '../components/Input/InputPassword/InputPassword';
 import { LocalDatePicker } from '../components/LocalDatePicker/LocalDatePicker';
 import {
   CLASS_NAMES_INPUT,
-  CLASS_MANES_LABEL,
+  CLASS_NAMES_LABEL,
 } from '@/components/Input/classNameConstants';
 import { Cookie } from '@/components/Cookie/Cookie';
 
@@ -110,20 +110,20 @@ export const DevPage: FC = () => {
           name="radio-buttons-group"
         >
           <FormControlLabel
-            className={CLASS_MANES_LABEL.end}
+            className={CLASS_NAMES_LABEL.end}
             value="До стены 1"
             control={<Radio />}
             label="До стены 1"
           />
           <FormControlLabel
-            className={CLASS_MANES_LABEL.end}
+            className={CLASS_NAMES_LABEL.end}
             value="До стены 3"
             control={<Radio />}
             label="До стены 3"
           />
         </RadioGroup>
         <FormControlLabel
-          className={CLASS_MANES_LABEL.start}
+          className={CLASS_NAMES_LABEL.start}
           label="Я дизайнер интерьеров"
           control={<Checkbox />}
         />

--- a/src/mui/DevPage.tsx
+++ b/src/mui/DevPage.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
@@ -13,8 +14,9 @@ import {
   CLASS_NAMES_INPUT,
   CLASS_MANES_LABEL,
 } from '@/components/Input/classNameConstants';
+import { Cookie } from '@/components/Cookie/Cookie';
 
-export const DevPage = () => {
+export const DevPage: FC = () => {
   return (
     <>
       <Typography color="myGrey.grey100" variant="h1">
@@ -169,6 +171,7 @@ export const DevPage = () => {
           className={CLASS_NAMES_INPUT.light}
         />
       </Box>
+      <Cookie />
     </>
   );
 };


### PR DESCRIPTION
![image](https://github.com/dizi-izi-plan/dizi-izi-frontend/assets/75042307/f21bc4b4-42be-41e6-85bd-4f4dc01a120e)

features added:
- view of InfoModal with cookies consent message
- save cookie consent into localStorage
- show cookies consent modal when no cookie consent data in local storage

to do:
- change button when buttons components are ready