### PR TITLE
window and balcony images

### DIFF
--- a/src/components/Forms/SizesForm/Steps/Step1.tsx
+++ b/src/components/Forms/SizesForm/Steps/Step1.tsx
@@ -71,7 +71,7 @@ export const Walls = () => {
           min={MIN_WALLS_INPUT_LENGTH}
           max={MAX_WALLS_INPUT_LENGTH}
           onFocus={() => dispatch(addBedroomFocusedField(field.number))}
-          onBlur={() => dispatch(deleteBedroomFocusedField())}
+          onBlurHandler={() => dispatch(deleteBedroomFocusedField())}
           onKeyDown={(e) => {
             if (
               !'0123456789'.includes(e.key) &&

--- a/src/components/Forms/SizesForm/Steps/Step2.tsx
+++ b/src/components/Forms/SizesForm/Steps/Step2.tsx
@@ -1,10 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useAppDispatch } from '@/redux/hooks';
-import {
-  addBedroomFocusedField,
-  deleteBedroomFocusedField,
-} from '@/redux/slices/focusedFields-slice';
 import { TextFieldWrapper } from '@/components/Input/TextFieldWrapper';
 import {
   CLASS_NAMES_INPUT,
@@ -16,14 +11,14 @@ import { STEP2 } from '../formData';
 import { SelectWrapper } from '@/components/Input/SelectWrapper';
 import { RadioGroupWrapper } from '@/components/Input/RadioGroup/RadioGroupWrapper';
 import { useToWallRadios } from '@/hooks/useToWallRadios';
+import { useFocusedObject } from '@/hooks/useFocusedObject';
 import { SizesFormType } from '../types';
 import { WALLS } from '../formData';
 
 export const Door = () => {
-  const dispatch = useAppDispatch();
-  const [isHovered, setHovered] = useState<boolean>(false);
-  const [isFocused, setFocused] = useState<boolean>(false);
-
+  const { handleSetFocused, handleSetHovered } = useFocusedObject(
+    STEP2.doorSize.name,
+  );
   const { control, formState, watch, setValue } =
     useFormContext<SizesFormType>();
   const { errors, touchedFields } = formState;
@@ -43,14 +38,6 @@ export const Door = () => {
       });
   }, [selectedWall, setValue]);
 
-  useEffect(() => {
-    if (isHovered || isFocused) {
-      dispatch(addBedroomFocusedField(STEP2.doorSize.name));
-    } else {
-      dispatch(deleteBedroomFocusedField());
-    }
-  }, [dispatch, isHovered, isFocused]);
-
   return (
     <Stack gap={3}>
       <SelectWrapper
@@ -61,8 +48,8 @@ export const Door = () => {
         className={CLASS_NAMES_INPUT.grey}
       />
       <Stack
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
+        onMouseEnter={() => handleSetHovered(true)}
+        onMouseLeave={() => handleSetHovered(false)}
       >
         <TextFieldWrapper
           name={`${STEP2.doorSize.name}` as keyof SizesFormType}
@@ -75,8 +62,8 @@ export const Door = () => {
           errorMessage={
             (touchedFields.door?.size && errors?.door?.size?.message) || ''
           }
-          onFocus={() => setFocused(true)}
-          onBlurHandler={() => setFocused(false)}
+          onFocus={() => handleSetFocused(true)}
+          onBlurHandler={() => handleSetFocused(false)}
         />
         <Stack direction="row" gap={3} mt={3}>
           <TextFieldWrapper
@@ -87,8 +74,8 @@ export const Door = () => {
             type="number"
             step={1}
             max={MAX_WALLS_INPUT_LENGTH}
-            onFocus={() => setFocused(true)}
-            onBlurHandler={() => setFocused(false)}
+            onFocus={() => handleSetFocused(true)}
+            onBlurHandler={() => handleSetFocused(false)}
           />
           <RadioGroupWrapper
             name={`${STEP2.toWall.name}` as keyof SizesFormType}

--- a/src/components/Forms/SizesForm/Steps/Step2.tsx
+++ b/src/components/Forms/SizesForm/Steps/Step2.tsx
@@ -76,7 +76,7 @@ export const Door = () => {
             (touchedFields.door?.size && errors?.door?.size?.message) || ''
           }
           onFocus={() => setFocused(true)}
-          onBlur={() => setFocused(false)}
+          onBlurHandler={() => setFocused(false)}
         />
         <Stack direction="row" gap={3} mt={3}>
           <TextFieldWrapper
@@ -88,7 +88,7 @@ export const Door = () => {
             step={1}
             max={MAX_WALLS_INPUT_LENGTH}
             onFocus={() => setFocused(true)}
-            onBlur={() => setFocused(false)}
+            onBlurHandler={() => setFocused(false)}
           />
           <RadioGroupWrapper
             name={`${STEP2.toWall.name}` as keyof SizesFormType}

--- a/src/components/Forms/SizesForm/Steps/Step3/Window.tsx
+++ b/src/components/Forms/SizesForm/Steps/Step3/Window.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useMemo } from 'react';
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import { useAppDispatch } from '@/redux/hooks';
 import { useFormContext } from 'react-hook-form';
 import ClearIcon from '@mui/icons-material/Clear';
 import { RadioGroupWrapper } from '@/components/Input/RadioGroup/RadioGroupWrapper';
@@ -10,6 +12,10 @@ import {
 } from '@/components/Input/classNameConstants';
 import { Button, FormHelperText, Stack, Typography } from '@mui/material';
 import { useToWallRadios } from '@/hooks/useToWallRadios';
+import {
+  addBedroomFocusedField,
+  deleteBedroomFocusedField,
+} from '@/redux/slices/focusedFields-slice';
 import {
   MAX_WALLS_INPUT_LENGTH,
   MAX_WINDOW_INPUT_LENGTH,
@@ -29,6 +35,9 @@ export const Window = ({ index, handleRemove }: WindowProps) => {
     watch,
     setValue,
   } = useFormContext<SizesFormType>();
+  const dispatch = useAppDispatch();
+  const [isHovered, setHovered] = useState<boolean>(false);
+  const [isFocused, setFocused] = useState<boolean>(false);
 
   const selectedWall = watch(
     `windows.windows.${index}.${STEP3.wallNumber.name}`,
@@ -47,6 +56,18 @@ export const Window = ({ index, handleRemove }: WindowProps) => {
       });
   }, [selectedWall, setValue, index]);
 
+  useEffect(() => {
+    if (isHovered || isFocused) {
+      dispatch(
+        addBedroomFocusedField(
+          `windows.windows.${index}.${STEP3.windowSize.name}`,
+        ),
+      );
+    } else {
+      dispatch(deleteBedroomFocusedField());
+    }
+  }, [dispatch, isHovered, isFocused, index]);
+
   const options = useMemo(() => {
     const doorWallNumber = watch('door.wallNumber');
     return STEP3.wallNumber.options.filter(
@@ -64,7 +85,11 @@ export const Window = ({ index, handleRemove }: WindowProps) => {
           <ClearIcon />
         </Button>
       </Stack>
-      <Stack gap={3}>
+      <Stack
+        gap={3}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
         <SelectWrapper
           name={`windows.windows.${index}.${STEP3.wallNumber.name}`}
           control={control}
@@ -85,6 +110,8 @@ export const Window = ({ index, handleRemove }: WindowProps) => {
               errors?.windows?.windows?.[index]?.size?.message) ||
             ''
           }
+          onFocus={() => setFocused(true)}
+          onBlurHandler={() => setFocused(false)}
         />
         <Stack>
           <Stack direction="row" gap={3}>
@@ -96,6 +123,8 @@ export const Window = ({ index, handleRemove }: WindowProps) => {
               type="number"
               step={1}
               max={MAX_WALLS_INPUT_LENGTH}
+              onFocus={() => setFocused(true)}
+              onBlurHandler={() => setFocused(false)}
             />
             <RadioGroupWrapper
               name={`windows.windows.${index}.${STEP3.toWall.name}`}

--- a/src/components/Forms/SizesForm/Steps/Step3/Window.tsx
+++ b/src/components/Forms/SizesForm/Steps/Step3/Window.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
-import { useAppDispatch } from '@/redux/hooks';
+import { useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import ClearIcon from '@mui/icons-material/Clear';
 import { RadioGroupWrapper } from '@/components/Input/RadioGroup/RadioGroupWrapper';
@@ -12,10 +11,7 @@ import {
 } from '@/components/Input/classNameConstants';
 import { Button, FormHelperText, Stack, Typography } from '@mui/material';
 import { useToWallRadios } from '@/hooks/useToWallRadios';
-import {
-  addBedroomFocusedField,
-  deleteBedroomFocusedField,
-} from '@/redux/slices/focusedFields-slice';
+import { useFocusedObject } from '@/hooks/useFocusedObject';
 import {
   MAX_WALLS_INPUT_LENGTH,
   MAX_WINDOW_INPUT_LENGTH,
@@ -35,10 +31,9 @@ export const Window = ({ index, handleRemove }: WindowProps) => {
     watch,
     setValue,
   } = useFormContext<SizesFormType>();
-  const dispatch = useAppDispatch();
-  const [isHovered, setHovered] = useState<boolean>(false);
-  const [isFocused, setFocused] = useState<boolean>(false);
-
+  const { handleSetFocused, handleSetHovered } = useFocusedObject(
+    `windows.windows.${index}.${STEP3.windowSize.name}`,
+  );
   const selectedWall = watch(
     `windows.windows.${index}.${STEP3.wallNumber.name}`,
   );
@@ -55,18 +50,6 @@ export const Window = ({ index, handleRemove }: WindowProps) => {
         shouldValidate: true,
       });
   }, [selectedWall, setValue, index]);
-
-  useEffect(() => {
-    if (isHovered || isFocused) {
-      dispatch(
-        addBedroomFocusedField(
-          `windows.windows.${index}.${STEP3.windowSize.name}`,
-        ),
-      );
-    } else {
-      dispatch(deleteBedroomFocusedField());
-    }
-  }, [dispatch, isHovered, isFocused, index]);
 
   const options = useMemo(() => {
     const doorWallNumber = watch('door.wallNumber');
@@ -87,8 +70,8 @@ export const Window = ({ index, handleRemove }: WindowProps) => {
       </Stack>
       <Stack
         gap={3}
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
+        onMouseEnter={() => handleSetHovered(true)}
+        onMouseLeave={() => handleSetHovered(false)}
       >
         <SelectWrapper
           name={`windows.windows.${index}.${STEP3.wallNumber.name}`}
@@ -110,8 +93,8 @@ export const Window = ({ index, handleRemove }: WindowProps) => {
               errors?.windows?.windows?.[index]?.size?.message) ||
             ''
           }
-          onFocus={() => setFocused(true)}
-          onBlurHandler={() => setFocused(false)}
+          onFocus={() => handleSetFocused(true)}
+          onBlurHandler={() => handleSetFocused(false)}
         />
         <Stack>
           <Stack direction="row" gap={3}>
@@ -123,8 +106,8 @@ export const Window = ({ index, handleRemove }: WindowProps) => {
               type="number"
               step={1}
               max={MAX_WALLS_INPUT_LENGTH}
-              onFocus={() => setFocused(true)}
-              onBlurHandler={() => setFocused(false)}
+              onFocus={() => handleSetFocused(true)}
+              onBlurHandler={() => handleSetFocused(false)}
             />
             <RadioGroupWrapper
               name={`windows.windows.${index}.${STEP3.toWall.name}`}

--- a/src/components/Forms/SizesForm/Steps/Step3/WindowWithBalcony.tsx
+++ b/src/components/Forms/SizesForm/Steps/Step3/WindowWithBalcony.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useMemo } from 'react';
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import { useAppDispatch } from '@/redux/hooks';
 import { useFormContext } from 'react-hook-form';
 import ClearIcon from '@mui/icons-material/Clear';
 import { RadioGroupWrapper } from '@/components/Input/RadioGroup/RadioGroupWrapper';
@@ -10,6 +12,10 @@ import {
 } from '@/components/Input/classNameConstants';
 import { Button, FormHelperText, Stack, Typography } from '@mui/material';
 import { useToWallRadios } from '@/hooks/useToWallRadios';
+import {
+  addBedroomFocusedField,
+  deleteBedroomFocusedField,
+} from '@/redux/slices/focusedFields-slice';
 import {
   MAX_DOOR_INPUT_LENGTH,
   MAX_WALLS_INPUT_LENGTH,
@@ -33,6 +39,9 @@ export const WindowWithBalcony = ({
     watch,
     setValue,
   } = useFormContext<SizesFormType>();
+  const dispatch = useAppDispatch();
+  const [isHovered, setHovered] = useState<boolean>(false);
+  const [isFocused, setFocused] = useState<boolean>(false);
 
   const selectedWall = watch(
     `windows.windows.${index}.${STEP3.wallNumber.name}`,
@@ -50,6 +59,18 @@ export const WindowWithBalcony = ({
         shouldValidate: true,
       });
   }, [selectedWall, setValue, index]);
+
+  useEffect(() => {
+    if (isHovered || isFocused) {
+      dispatch(
+        addBedroomFocusedField(
+          `windows.windows.${index}.${STEP3.windowSize.name}`,
+        ),
+      );
+    } else {
+      dispatch(deleteBedroomFocusedField());
+    }
+  }, [dispatch, isHovered, isFocused, index]);
 
   const options = useMemo(() => {
     const doorWallNumber = watch('door.wallNumber');
@@ -76,54 +97,68 @@ export const WindowWithBalcony = ({
           options={options}
           className={CLASS_NAMES_INPUT.grey}
         />
-        <TextFieldWrapper
-          name={`windows.windows.${index}.${STEP3.windowSize.name}`}
-          control={control}
-          className={CLASS_NAMES_INPUT.grey}
-          placeholder={STEP3.windowSize.placeholder}
-          type="number"
-          step={1}
-          max={MAX_WINDOW_INPUT_LENGTH}
-          errorMessage={
-            (touchedFields.windows?.windows?.[index]?.size &&
-              errors?.windows?.windows?.[index]?.size?.message) ||
-            ''
-          }
-        />
-        <TextFieldWrapper
-          name={`windows.windows.${index}.${STEP3.doorSize.name}`}
-          control={control}
-          className={CLASS_NAMES_INPUT.grey}
-          placeholder={STEP3.doorSize.placeholder}
-          type="number"
-          step={1}
-          max={MAX_DOOR_INPUT_LENGTH}
-          errorMessage={
-            (touchedFields.windows?.windows?.[index]?.doorSize &&
-              errors?.windows?.windows?.[index]?.doorSize?.message) ||
-            ''
-          }
-        />
-        <Stack>
-          <Stack direction="row" gap={3}>
-            <TextFieldWrapper
-              name={`windows.windows.${index}.${STEP3.fromWindowTo.name}`}
-              control={control}
-              className={CLASS_NAMES_INPUT.grey}
-              placeholder={STEP3.fromWindowTo.placeholder}
-              type="number"
-              step={1}
-              max={MAX_WALLS_INPUT_LENGTH}
-            />
-            <RadioGroupWrapper
-              name={`windows.windows.${index}.${STEP3.toWall.name}`}
-              control={control}
-              className={CLASS_NAMES_LABEL.end}
-              radios={toWallRadios}
-              labelSx={{
-                marginRight: 0,
-              }}
-            />
+        <Stack
+          gap={3}
+          width="100%"
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+        >
+          <TextFieldWrapper
+            name={`windows.windows.${index}.${STEP3.windowSize.name}`}
+            control={control}
+            className={CLASS_NAMES_INPUT.grey}
+            placeholder={STEP3.windowSize.placeholder}
+            type="number"
+            step={1}
+            max={MAX_WINDOW_INPUT_LENGTH}
+            errorMessage={
+              (touchedFields.windows?.windows?.[index]?.size &&
+                errors?.windows?.windows?.[index]?.size?.message) ||
+              ''
+            }
+            onFocus={() => setFocused(true)}
+            onBlurHandler={() => setFocused(false)}
+          />
+          <TextFieldWrapper
+            name={`windows.windows.${index}.${STEP3.doorSize.name}`}
+            control={control}
+            className={CLASS_NAMES_INPUT.grey}
+            placeholder={STEP3.doorSize.placeholder}
+            type="number"
+            step={1}
+            max={MAX_DOOR_INPUT_LENGTH}
+            errorMessage={
+              (touchedFields.windows?.windows?.[index]?.doorSize &&
+                errors?.windows?.windows?.[index]?.doorSize?.message) ||
+              ''
+            }
+            onFocus={() => setFocused(true)}
+            onBlurHandler={() => setFocused(false)}
+          />
+
+          <Stack>
+            <Stack direction="row" gap={3}>
+              <TextFieldWrapper
+                name={`windows.windows.${index}.${STEP3.fromWindowTo.name}`}
+                control={control}
+                className={CLASS_NAMES_INPUT.grey}
+                placeholder={STEP3.fromWindowTo.placeholder}
+                type="number"
+                step={1}
+                max={MAX_WALLS_INPUT_LENGTH}
+                onFocus={() => setFocused(true)}
+                onBlurHandler={() => setFocused(false)}
+              />
+              <RadioGroupWrapper
+                name={`windows.windows.${index}.${STEP3.toWall.name}`}
+                control={control}
+                className={CLASS_NAMES_LABEL.end}
+                radios={toWallRadios}
+                labelSx={{
+                  marginRight: 0,
+                }}
+              />
+            </Stack>
           </Stack>
         </Stack>
         {touchedFields.windows?.windows?.[index]?.distanceToWall &&

--- a/src/components/Forms/SizesForm/Steps/Step3/WindowWithBalcony.tsx
+++ b/src/components/Forms/SizesForm/Steps/Step3/WindowWithBalcony.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
-import { useAppDispatch } from '@/redux/hooks';
+import { useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import ClearIcon from '@mui/icons-material/Clear';
 import { RadioGroupWrapper } from '@/components/Input/RadioGroup/RadioGroupWrapper';
@@ -12,10 +11,7 @@ import {
 } from '@/components/Input/classNameConstants';
 import { Button, FormHelperText, Stack, Typography } from '@mui/material';
 import { useToWallRadios } from '@/hooks/useToWallRadios';
-import {
-  addBedroomFocusedField,
-  deleteBedroomFocusedField,
-} from '@/redux/slices/focusedFields-slice';
+import { useFocusedObject } from '@/hooks/useFocusedObject';
 import {
   MAX_DOOR_INPUT_LENGTH,
   MAX_WALLS_INPUT_LENGTH,
@@ -39,10 +35,9 @@ export const WindowWithBalcony = ({
     watch,
     setValue,
   } = useFormContext<SizesFormType>();
-  const dispatch = useAppDispatch();
-  const [isHovered, setHovered] = useState<boolean>(false);
-  const [isFocused, setFocused] = useState<boolean>(false);
-
+  const { handleSetFocused, handleSetHovered } = useFocusedObject(
+    `windows.windows.${index}.${STEP3.windowSize.name}`,
+  );
   const selectedWall = watch(
     `windows.windows.${index}.${STEP3.wallNumber.name}`,
   );
@@ -59,18 +54,6 @@ export const WindowWithBalcony = ({
         shouldValidate: true,
       });
   }, [selectedWall, setValue, index]);
-
-  useEffect(() => {
-    if (isHovered || isFocused) {
-      dispatch(
-        addBedroomFocusedField(
-          `windows.windows.${index}.${STEP3.windowSize.name}`,
-        ),
-      );
-    } else {
-      dispatch(deleteBedroomFocusedField());
-    }
-  }, [dispatch, isHovered, isFocused, index]);
 
   const options = useMemo(() => {
     const doorWallNumber = watch('door.wallNumber');
@@ -100,8 +83,8 @@ export const WindowWithBalcony = ({
         <Stack
           gap={3}
           width="100%"
-          onMouseEnter={() => setHovered(true)}
-          onMouseLeave={() => setHovered(false)}
+          onMouseEnter={() => handleSetHovered(true)}
+          onMouseLeave={() => handleSetHovered(false)}
         >
           <TextFieldWrapper
             name={`windows.windows.${index}.${STEP3.windowSize.name}`}
@@ -116,8 +99,8 @@ export const WindowWithBalcony = ({
                 errors?.windows?.windows?.[index]?.size?.message) ||
               ''
             }
-            onFocus={() => setFocused(true)}
-            onBlurHandler={() => setFocused(false)}
+            onFocus={() => handleSetFocused(true)}
+            onBlurHandler={() => handleSetFocused(false)}
           />
           <TextFieldWrapper
             name={`windows.windows.${index}.${STEP3.doorSize.name}`}
@@ -132,8 +115,8 @@ export const WindowWithBalcony = ({
                 errors?.windows?.windows?.[index]?.doorSize?.message) ||
               ''
             }
-            onFocus={() => setFocused(true)}
-            onBlurHandler={() => setFocused(false)}
+            onFocus={() => handleSetFocused(true)}
+            onBlurHandler={() => handleSetFocused(false)}
           />
 
           <Stack>
@@ -146,8 +129,8 @@ export const WindowWithBalcony = ({
                 type="number"
                 step={1}
                 max={MAX_WALLS_INPUT_LENGTH}
-                onFocus={() => setFocused(true)}
-                onBlurHandler={() => setFocused(false)}
+                onFocus={() => handleSetFocused(true)}
+                onBlurHandler={() => handleSetFocused(false)}
               />
               <RadioGroupWrapper
                 name={`windows.windows.${index}.${STEP3.toWall.name}`}

--- a/src/components/Forms/SizesForm/Steps/utils/consts.ts
+++ b/src/components/Forms/SizesForm/Steps/utils/consts.ts
@@ -1,5 +1,5 @@
 export const MIN_DISTANCE_TO_WALL = 50;
-export const MIN_DISTANCE_BETWEEN_WINDOWS = 40;
+export const MIN_DISTANCE_BETWEEN_WINDOWS = 400;
 
 export const ERROR_MESSAGES = {
   required: 'Обязательное поле',
@@ -14,6 +14,6 @@ export const ERROR_MESSAGES = {
   maxDistanceToWall: 'Расстояние до стены слишком большое',
   maxWindowAmount: 'Количество окон не может превышать 2шт',
   windowsSameWallSize:
-    'Размеры окон не могут быть больше размера выбранной стены. Минимальное расстояние между окнами - 40мм',
-  windowsSameWallWindowDistance: 'Минимальное расстояние между окнами - 40мм',
+    'Размеры окон не могут быть больше размера выбранной стены. Минимальное расстояние между окнами - 400мм',
+  windowsSameWallWindowDistance: 'Минимальное расстояние между окнами - 400мм',
 };

--- a/src/components/Forms/SizesForm/Steps/utils/consts.ts
+++ b/src/components/Forms/SizesForm/Steps/utils/consts.ts
@@ -15,4 +15,5 @@ export const ERROR_MESSAGES = {
   maxWindowAmount: 'Количество окон не может превышать 2шт',
   windowsSameWallSize:
     'Размеры окон не могут быть больше размера выбранной стены. Минимальное расстояние между окнами - 40мм',
+  windowsSameWallWindowDistance: 'Минимальное расстояние между окнами - 40мм',
 };

--- a/src/components/Forms/SizesForm/Steps/utils/helpers.ts
+++ b/src/components/Forms/SizesForm/Steps/utils/helpers.ts
@@ -189,21 +189,24 @@ export const checkWindowsOfSameWall = (
     return;
   }
 
-  const {
-    wallNumber: firstWallNumber,
-    size: firstSize,
-    doorSize: firstDoorSize = 0,
-    distanceToWall: firstDistanceToWall,
-    toWall: firstToWall,
-  } = values.windows.windows[0];
-
-  const {
-    wallNumber: secondWallNumber,
-    size: secondSize,
-    doorSize: secondDoorSize = 0,
-    distanceToWall: secondDistanceToWall,
-    toWall: secondToWall,
-  } = values.windows.windows[1];
+  const [
+    {
+      wallNumber: firstWallNumber,
+      size: firstSize,
+      doorSize: firstDoorSize = 0,
+      distanceToWall: firstDistanceToWall,
+      toWall: firstToWall,
+    },
+    {
+      wallNumber: secondWallNumber,
+      size: secondSize,
+      doorSize: secondDoorSize = 0,
+      distanceToWall: secondDistanceToWall,
+      toWall: secondToWall,
+    },
+  ] = [...values.windows.windows].sort(
+    (a, b) => Number(a.distanceToWall) - Number(b.distanceToWall),
+  );
 
   if (firstWallNumber !== secondWallNumber) {
     return;

--- a/src/components/Forms/SizesForm/Steps/utils/helpers.ts
+++ b/src/components/Forms/SizesForm/Steps/utils/helpers.ts
@@ -194,6 +194,7 @@ export const checkWindowsOfSameWall = (
     size: firstSize,
     doorSize: firstDoorSize = 0,
     distanceToWall: firstDistanceToWall,
+    toWall: firstToWall,
   } = values.windows.windows[0];
 
   const {
@@ -201,6 +202,7 @@ export const checkWindowsOfSameWall = (
     size: secondSize,
     doorSize: secondDoorSize = 0,
     distanceToWall: secondDistanceToWall,
+    toWall: secondToWall,
   } = values.windows.windows[1];
 
   if (firstWallNumber !== secondWallNumber) {
@@ -217,13 +219,34 @@ export const checkWindowsOfSameWall = (
   const wallSize = values.walls[wallNum as WALL_NUM];
 
   const sum =
-    Number(firstSize) +
-    Number(firstDoorSize) +
-    Number(secondSize) +
-    Number(secondDoorSize) +
-    MIN_DISTANCE_BETWEEN_WINDOWS +
-    Number(firstDistanceToWall) +
-    Number(secondDistanceToWall);
+    firstToWall === secondToWall
+      ? Number(secondDistanceToWall) +
+        Number(secondSize) +
+        Number(secondDoorSize) +
+        MIN_DISTANCE_TO_WALL
+      : Number(firstSize) +
+        Number(firstDoorSize) +
+        Number(secondSize) +
+        Number(secondDoorSize) +
+        MIN_DISTANCE_BETWEEN_WINDOWS +
+        Number(firstDistanceToWall) +
+        Number(secondDistanceToWall);
+
+  const firstEnd =
+    Number(firstDistanceToWall) + Number(firstSize) + Number(firstDoorSize);
+
+  const secondStart =
+    firstToWall === secondToWall
+      ? Number(secondDistanceToWall)
+      : Number(wallSize) -
+        (Number(secondDistanceToWall) +
+          Number(secondSize) +
+          Number(secondDoorSize));
+
+  if (secondStart - firstEnd < MIN_DISTANCE_BETWEEN_WINDOWS) {
+    issue.message = ERROR_MESSAGES.windowsSameWallWindowDistance;
+    setFieldError(issue, setError);
+  }
 
   if (sum > Number(wallSize)) {
     issue.message = ERROR_MESSAGES.windowsSameWallSize;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -22,6 +22,7 @@ const headerLinksData = [
 export const Header = () => {
   const isAuth = useAuth();
   const { data } = useGetUserDataQuery('');
+  console.log(data);
 
   return (
     <header>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -22,7 +22,6 @@ const headerLinksData = [
 export const Header = () => {
   const isAuth = useAuth();
   const { data } = useGetUserDataQuery('');
-  console.log(data);
 
   return (
     <header>

--- a/src/components/Input/TextFieldWrapper.tsx
+++ b/src/components/Input/TextFieldWrapper.tsx
@@ -15,12 +15,14 @@ export type ControlledInputProps<T extends FieldValues> = TextFieldProps &
     max?: number;
     step?: number;
     onChangeHandler?: (e: ChangeEvent<HTMLInputElement>) => void;
+    onBlurHandler?: () => void;
   };
 
 export const TextFieldWrapper = <T extends FieldValues>({
   name,
   control,
   errorMessage,
+  onBlurHandler,
   onChangeHandler,
   ...props
 }: ControlledInputProps<T>) => {
@@ -39,6 +41,7 @@ export const TextFieldWrapper = <T extends FieldValues>({
   };
 
   const onBlur = () => {
+    onBlurHandler?.();
     field.onBlur();
   };
 

--- a/src/components/Measurements/Measurements.tsx
+++ b/src/components/Measurements/Measurements.tsx
@@ -34,12 +34,7 @@ export const Measurements = () => {
     resolver: zodResolver(SizesFormValidation),
   });
 
-  const { control, trigger, watch, formState } = methods;
-  const { errors } = formState;
-
-  if (Object.values(errors).length > 0) {
-    console.log('errors', errors);
-  }
+  const { control, trigger, watch } = methods;
 
   useEffect(() => {
     const validateStep = async () => {
@@ -121,6 +116,7 @@ export const Measurements = () => {
       <Stack direction="row" width="100%" justifyContent="space-between">
         <MeasurementsImage
           stepOne={currentStep === 0}
+          stepTwo={currentStep === 1}
           stepThree={currentStep === 2}
           control={control}
           display={currentStep === 3 ? 'none' : undefined}

--- a/src/components/Measurements/MeasurementsImage.tsx
+++ b/src/components/Measurements/MeasurementsImage.tsx
@@ -37,7 +37,7 @@ export const MeasurementsImage = ({
 
   const door = useDoorFields(control, stepOne);
 
-  const { windows, balconies } = useWindowFields(control, stepOne || stepTwo);
+  const windows = useWindowFields(control, stepOne || stepTwo);
 
   const [currentSizes, setCurrentSizes] = useState({
     width: 640,
@@ -190,25 +190,29 @@ export const MeasurementsImage = ({
           wallThickness={wallThickness}
         />
         {stepThree &&
-          windows.map((window: TWindow, index: number) => (
-            <Window
-              key={index}
-              window={window}
-              horizontalWall={horizontalWall}
-              verticalWall={verticalWall}
-              wallThickness={wallThickness}
-            />
-          ))}
-        {stepThree &&
-          balconies.map((balcony: TWindow, index: number) => (
-            <Balcony
-              key={index}
-              balcony={balcony}
-              horizontalWall={horizontalWall}
-              verticalWall={verticalWall}
-              wallThickness={wallThickness}
-            />
-          ))}
+          windows.map((window: TWindow, index: number) => {
+            if ('openLeft' in window) {
+              return (
+                <Balcony
+                  key={index}
+                  balcony={window}
+                  horizontalWall={horizontalWall}
+                  verticalWall={verticalWall}
+                  wallThickness={wallThickness}
+                />
+              );
+            } else {
+              return (
+                <Window
+                  key={index}
+                  window={window}
+                  horizontalWall={horizontalWall}
+                  verticalWall={verticalWall}
+                  wallThickness={wallThickness}
+                />
+              );
+            }
+          })}
       </Stack>
     </Stack>
   );

--- a/src/components/Measurements/MeasurementsImage.tsx
+++ b/src/components/Measurements/MeasurementsImage.tsx
@@ -3,28 +3,28 @@
 import { useEffect, useMemo, useState, useRef } from 'react';
 import Stack, { StackProps } from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-
 import { WallNumbers } from './MeasurementsImageElements/WallNumbers';
 import { Door } from './MeasurementsImageElements/Door';
 import { Window } from './MeasurementsImageElements/Window';
 import { Balcony } from './MeasurementsImageElements/Balcony';
 import DoorTransparentIcon from '../../../public/assets/icons/measurements/icon_door-transparent.svg';
-import { TWindow, TBalcony } from './MeasurementsTypes';
+import { TWindow } from './MeasurementsTypes';
 import { SizesFormType } from '../Forms/SizesForm/types';
 import { Control } from 'react-hook-form';
-import { WALLS } from '@/components/Forms/SizesForm/formData';
 import { useDoorFields } from './hooks/useDoorFields';
 import { useWallsFields } from './hooks/useWallsFields';
+import { useWindowFields } from './hooks/useWindowFields';
 
 type MeasurementsImageProps = StackProps & {
   stepOne: boolean;
+  stepTwo: boolean;
   stepThree: boolean;
   control: Control<SizesFormType>;
 };
 
 export const MeasurementsImage = ({
   stepOne,
+  stepTwo,
   stepThree,
   control,
   ...props
@@ -37,28 +37,7 @@ export const MeasurementsImage = ({
 
   const door = useDoorFields(control, stepOne);
 
-  const [windows, setWindows] = useState<TWindow[]>([
-    {
-      wall: WALLS.second,
-      size: 1200,
-      distance: 500,
-      distanceFromLeft: false,
-      distanceFromRight: true,
-      isFocused: false,
-    },
-  ]);
-
-  const [balconies, setBalconies] = useState<TBalcony[]>([
-    {
-      wall: WALLS.first,
-      size: 1500,
-      distance: 500,
-      distanceFromLeft: true,
-      distanceFromRight: false,
-      openLeft: false,
-      isFocused: false,
-    },
-  ]);
+  const { windows, balconies } = useWindowFields(control, stepOne || stepTwo);
 
   const [currentSizes, setCurrentSizes] = useState({
     width: 640,
@@ -211,7 +190,7 @@ export const MeasurementsImage = ({
           wallThickness={wallThickness}
         />
         {stepThree &&
-          windows.map((window, index) => (
+          windows.map((window: TWindow, index: number) => (
             <Window
               key={index}
               window={window}
@@ -221,7 +200,7 @@ export const MeasurementsImage = ({
             />
           ))}
         {stepThree &&
-          balconies.map((balcony, index) => (
+          balconies.map((balcony: TWindow, index: number) => (
             <Balcony
               key={index}
               balcony={balcony}
@@ -230,105 +209,6 @@ export const MeasurementsImage = ({
               wallThickness={wallThickness}
             />
           ))}
-      </Stack>
-      {/*Раздел с кнопками для изменения параметров - ПРИМЕР для Кати и дизайнеров, пока нет формы. Удалить после*/}
-      <Stack position="absolute" bottom="-150px" left="0px" rowGap="20px">
-        <Stack
-          direction="row"
-          columnGap="20px"
-          display={stepThree ? undefined : 'none'}
-        >
-          <Typography>ОКНО</Typography>
-          <Button
-            variant="default"
-            sx={{ color: 'black.main', p: '10px 10px' }}
-            size="medium"
-            onClick={() => {
-              setWindows((prev) => {
-                const newWindow = prev[0];
-                if (newWindow.distanceFromLeft) {
-                  newWindow.distanceFromLeft = false;
-                  newWindow.distanceFromRight = true;
-                } else {
-                  newWindow.distanceFromLeft = true;
-                  newWindow.distanceFromRight = false;
-                }
-                return [newWindow];
-              });
-            }}
-          >
-            Поменять стену, от которой идет расчет
-          </Button>
-          <Button
-            variant="default"
-            sx={{ color: 'black.main', p: '10px 10px' }}
-            size="medium"
-            onClick={() => {
-              setWindows((prev) => {
-                const newWindow = prev[0];
-                newWindow.isFocused = !newWindow.isFocused;
-                return [newWindow];
-              });
-            }}
-          >
-            {windows[0].isFocused ? 'Убрать фокус' : 'Окно в фокусе'}
-          </Button>
-        </Stack>
-        <Stack
-          direction="row"
-          columnGap="20px"
-          display={stepThree ? undefined : 'none'}
-        >
-          <Typography>БАЛКОН</Typography>
-          <Button
-            variant="default"
-            sx={{ color: 'black.main', p: '10px 10px' }}
-            size="medium"
-            onClick={() => {
-              setBalconies((prev) => {
-                const newBalcony = prev[0];
-                if (newBalcony.distanceFromLeft) {
-                  newBalcony.distanceFromLeft = false;
-                  newBalcony.distanceFromRight = true;
-                } else {
-                  newBalcony.distanceFromLeft = true;
-                  newBalcony.distanceFromRight = false;
-                }
-                return [newBalcony];
-              });
-            }}
-          >
-            Поменять стену, от которой идет расчет
-          </Button>
-          <Button
-            variant="default"
-            sx={{ color: 'black.main', p: '10px 10px' }}
-            size="medium"
-            onClick={() => {
-              setBalconies((prev) => {
-                const newBalcony = prev[0];
-                newBalcony.openLeft = !newBalcony.openLeft;
-                return [newBalcony];
-              });
-            }}
-          >
-            Открыть {balconies[0].openLeft ? 'вправо' : 'влево'}
-          </Button>
-          <Button
-            variant="default"
-            sx={{ color: 'black.main', p: '10px 10px' }}
-            size="medium"
-            onClick={() => {
-              setBalconies((prev) => {
-                const newBalcony = prev[0];
-                newBalcony.isFocused = !newBalcony.isFocused;
-                return [newBalcony];
-              });
-            }}
-          >
-            {balconies[0].isFocused ? 'Убрать фокус' : 'Балкон в фокусе'}
-          </Button>
-        </Stack>
       </Stack>
     </Stack>
   );

--- a/src/components/Measurements/MeasurementsImageElements/Balcony.tsx
+++ b/src/components/Measurements/MeasurementsImageElements/Balcony.tsx
@@ -3,13 +3,13 @@ import { useMemo } from 'react';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 
-import { TBalcony } from '../MeasurementsTypes';
+import { TWindow } from '../MeasurementsTypes';
 import { Line } from './Line';
 import { ElementContainer } from './ElementContainer';
 import { getBalconyStyles } from './getElementsStyles';
 
 type BalconyProps = {
-  balcony: TBalcony;
+  balcony: TWindow;
   horizontalWall: number;
   verticalWall: number;
   wallThickness: number;

--- a/src/components/Measurements/MeasurementsImageElements/ElementContainer.tsx
+++ b/src/components/Measurements/MeasurementsImageElements/ElementContainer.tsx
@@ -68,9 +68,7 @@ export const ElementContainer = ({
           height={elementStyles[element.wall].line.height}
           width={elementStyles[element.wall].line.width}
           sx={{
-            backgroundColor: element.isFocused
-              ? 'primary.main'
-              : 'myGrey.grey700',
+            backgroundColor: element.isFocused ? 'primary.main' : 'transparent',
           }}
         ></Box>
         {element.distance > 0 ? (
@@ -81,7 +79,7 @@ export const ElementContainer = ({
                 sx={{
                   position: 'absolute',
                   left: '-10px',
-                  color: element.isFocused ? 'primary.main' : 'myGrey.grey700',
+                  color: element.isFocused ? 'primary.main' : 'transparent',
                 }}
               />
               <ArrowRightIcon
@@ -89,7 +87,7 @@ export const ElementContainer = ({
                 sx={{
                   position: 'absolute',
                   right: '-10px',
-                  color: element.isFocused ? 'primary.main' : 'myGrey.grey700',
+                  color: element.isFocused ? 'primary.main' : 'transparent',
                 }}
               />
             </>
@@ -100,7 +98,7 @@ export const ElementContainer = ({
                 sx={{
                   position: 'absolute',
                   top: '-10px',
-                  color: element.isFocused ? 'primary.main' : 'myGrey.grey700',
+                  color: element.isFocused ? 'primary.main' : 'transparent',
                 }}
               />
               <ArrowDropDownIcon
@@ -108,7 +106,7 @@ export const ElementContainer = ({
                 sx={{
                   position: 'absolute',
                   bottom: '-10px',
-                  color: element.isFocused ? 'primary.main' : 'myGrey.grey700',
+                  color: element.isFocused ? 'primary.main' : 'transparent',
                 }}
               />
             </>

--- a/src/components/Measurements/MeasurementsTypes.tsx
+++ b/src/components/Measurements/MeasurementsTypes.tsx
@@ -7,13 +7,11 @@ export type TWindow = {
   distanceFromLeft: boolean;
   distanceFromRight: boolean;
   isFocused: boolean;
+  openLeft?: boolean;
 };
 
-export type TBalcony = TWindow & {
+export type TDoor = TWindow & {
   openLeft: boolean;
-};
-
-export type TDoor = TBalcony & {
   openInside: boolean;
 };
 

--- a/src/components/Measurements/hooks/useDoorFields.tsx
+++ b/src/components/Measurements/hooks/useDoorFields.tsx
@@ -16,7 +16,7 @@ import {
 
 export const useDoorFields = (
   control: Control<SizesFormType>,
-  invisible: boolean,
+  isInvisible: boolean,
 ): TDoor => {
   const fieldOnFocus = useAppSelector(selectFieldOnFocus);
 
@@ -53,7 +53,7 @@ export const useDoorFields = (
 
   return {
     wall: doorForm?.wallNumber as WALLS_NAMES_TYPE,
-    size: errors.door?.size || invisible ? 0 : Number(doorForm?.size),
+    size: errors.door?.size || isInvisible ? 0 : Number(doorForm?.size),
     distance: errors.door?.distanceToWall
       ? 0
       : Number(doorForm?.distanceToWall),

--- a/src/components/Measurements/hooks/useWindowFields.tsx
+++ b/src/components/Measurements/hooks/useWindowFields.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useMemo } from 'react';
+import { Control, useWatch, useFormState } from 'react-hook-form';
+import { useAppSelector } from '@/redux/hooks';
+import { selectFieldOnFocus } from '@/redux/slices/focusedFields-slice';
+import { WALLS, SIDE, STEP3 } from '@/components/Forms/SizesForm/formData';
+import { TWindow } from '../MeasurementsTypes';
+import {
+  SizesFormType,
+  WALLS_NAMES_TYPE,
+} from '@/components/Forms/SizesForm/types';
+
+export const useWindowFields = (
+  control: Control<SizesFormType>,
+  invisible: boolean,
+): { windows: TWindow[]; balconies: TWindow[] } => {
+  const fieldOnFocus = useAppSelector(selectFieldOnFocus);
+
+  const { errors } = useFormState({
+    control,
+  });
+
+  const windowForm = useWatch({
+    control,
+  }).windows;
+
+  const distanceFromLeft = useCallback(
+    (currentWall: WALLS_NAMES_TYPE, toWall: WALLS_NAMES_TYPE) => {
+      return (
+        (currentWall === WALLS.first && toWall === WALLS.forth) ||
+        (currentWall === WALLS.second && toWall === WALLS.first) ||
+        (currentWall === WALLS.third && toWall === WALLS.second) ||
+        (currentWall === WALLS.forth && toWall === WALLS.third)
+      );
+    },
+    [],
+  );
+
+  const distanceFromRight = useCallback(
+    (currentWall: WALLS_NAMES_TYPE, toWall: WALLS_NAMES_TYPE) => {
+      return (
+        (currentWall === WALLS.first && toWall === WALLS.second) ||
+        (currentWall === WALLS.second && toWall === WALLS.third) ||
+        (currentWall === WALLS.third && toWall === WALLS.forth) ||
+        (currentWall === WALLS.forth && toWall === WALLS.first)
+      );
+    },
+    [],
+  );
+
+  const isFocused = useCallback(
+    (index: number) => {
+      if (fieldOnFocus === `windows.windows.${index}.${STEP3.windowSize.name}`)
+        return true;
+      return false;
+    },
+    [fieldOnFocus],
+  );
+
+  const allWindow = useMemo(() => {
+    if (windowForm && windowForm.windows) {
+      return windowForm.windows
+        .filter((el) => el.wallNumber)
+        .map((window, index) => {
+          if (window.doorSize) {
+            return {
+              wall: window.wallNumber as WALLS_NAMES_TYPE,
+              size:
+                errors.windows?.windows?.[index]?.size?.message ||
+                errors.windows?.windows?.[index]?.doorSize?.message ||
+                invisible
+                  ? 0
+                  : Number(window.size) + Number(window.doorSize),
+              distance: errors.windows?.windows?.[index]?.distanceToWall
+                ? 0
+                : Number(window.distanceToWall),
+              distanceFromLeft: distanceFromLeft(
+                window.wallNumber as WALLS_NAMES_TYPE,
+                window.toWall as WALLS_NAMES_TYPE,
+              ),
+              distanceFromRight: distanceFromRight(
+                window.wallNumber as WALLS_NAMES_TYPE,
+                window.toWall as WALLS_NAMES_TYPE,
+              ),
+              openLeft: window.side === SIDE.left,
+              isFocused: isFocused(index),
+            };
+          } else {
+            return {
+              wall: window.wallNumber as WALLS_NAMES_TYPE,
+              size:
+                errors.windows?.windows?.[index]?.size?.message || invisible
+                  ? 0
+                  : Number(window.size),
+              distance: errors.windows?.windows?.[index]?.distanceToWall
+                ? 0
+                : Number(window.distanceToWall),
+              distanceFromLeft: distanceFromLeft(
+                window.wallNumber as WALLS_NAMES_TYPE,
+                window.toWall as WALLS_NAMES_TYPE,
+              ),
+              distanceFromRight: distanceFromRight(
+                window.wallNumber as WALLS_NAMES_TYPE,
+                window.toWall as WALLS_NAMES_TYPE,
+              ),
+              isFocused: isFocused(index),
+            };
+          }
+        });
+    } else {
+      return [];
+    }
+  }, [
+    distanceFromLeft,
+    distanceFromRight,
+    errors.windows?.windows,
+    invisible,
+    isFocused,
+    windowForm,
+  ]);
+
+  if (windowForm && windowForm.windows) {
+    console.log(allWindow);
+    return {
+      balconies: allWindow.filter((balcony) => 'openLeft' in balcony),
+      windows: allWindow.filter((window) => !('openLeft' in window)),
+    };
+  } else return { windows: [], balconies: [] };
+};

--- a/src/components/Measurements/hooks/useWindowFields.tsx
+++ b/src/components/Measurements/hooks/useWindowFields.tsx
@@ -58,54 +58,55 @@ export const useWindowFields = (
 
   const allWindow = useMemo(() => {
     if (windowForm && windowForm.windows) {
-      return windowForm.windows
-        .filter((el) => el.wallNumber)
-        .map((window, index) => {
-          if (window.doorSize) {
-            return {
-              wall: window.wallNumber as WALLS_NAMES_TYPE,
-              size:
-                errors.windows?.windows?.[index]?.size?.message ||
-                errors.windows?.windows?.[index]?.doorSize?.message ||
-                invisible
-                  ? 0
-                  : Number(window.size) + Number(window.doorSize),
-              distance: errors.windows?.windows?.[index]?.distanceToWall
+      return windowForm.windows.map((window, index) => {
+        if (window.doorSize) {
+          return {
+            wall: window.wallNumber as WALLS_NAMES_TYPE,
+            size:
+              errors?.windows?.windows?.message ||
+              errors.windows?.windows?.[index]?.size?.message ||
+              errors.windows?.windows?.[index]?.doorSize?.message ||
+              invisible
                 ? 0
-                : Number(window.distanceToWall),
-              distanceFromLeft: distanceFromLeft(
-                window.wallNumber as WALLS_NAMES_TYPE,
-                window.toWall as WALLS_NAMES_TYPE,
-              ),
-              distanceFromRight: distanceFromRight(
-                window.wallNumber as WALLS_NAMES_TYPE,
-                window.toWall as WALLS_NAMES_TYPE,
-              ),
-              openLeft: window.side === SIDE.left,
-              isFocused: isFocused(index),
-            };
-          } else {
-            return {
-              wall: window.wallNumber as WALLS_NAMES_TYPE,
-              size:
-                errors.windows?.windows?.[index]?.size?.message || invisible
-                  ? 0
-                  : Number(window.size),
-              distance: errors.windows?.windows?.[index]?.distanceToWall
+                : Number(window.size) + Number(window.doorSize),
+            distance: errors.windows?.windows?.[index]?.distanceToWall
+              ? 0
+              : Number(window.distanceToWall),
+            distanceFromLeft: distanceFromLeft(
+              window.wallNumber as WALLS_NAMES_TYPE,
+              window.toWall as WALLS_NAMES_TYPE,
+            ),
+            distanceFromRight: distanceFromRight(
+              window.wallNumber as WALLS_NAMES_TYPE,
+              window.toWall as WALLS_NAMES_TYPE,
+            ),
+            openLeft: window.side === SIDE.left,
+            isFocused: isFocused(index),
+          };
+        } else {
+          return {
+            wall: window.wallNumber as WALLS_NAMES_TYPE,
+            size:
+              errors?.windows?.windows?.message ||
+              errors.windows?.windows?.[index]?.size?.message ||
+              invisible
                 ? 0
-                : Number(window.distanceToWall),
-              distanceFromLeft: distanceFromLeft(
-                window.wallNumber as WALLS_NAMES_TYPE,
-                window.toWall as WALLS_NAMES_TYPE,
-              ),
-              distanceFromRight: distanceFromRight(
-                window.wallNumber as WALLS_NAMES_TYPE,
-                window.toWall as WALLS_NAMES_TYPE,
-              ),
-              isFocused: isFocused(index),
-            };
-          }
-        });
+                : Number(window.size),
+            distance: errors.windows?.windows?.[index]?.distanceToWall
+              ? 0
+              : Number(window.distanceToWall),
+            distanceFromLeft: distanceFromLeft(
+              window.wallNumber as WALLS_NAMES_TYPE,
+              window.toWall as WALLS_NAMES_TYPE,
+            ),
+            distanceFromRight: distanceFromRight(
+              window.wallNumber as WALLS_NAMES_TYPE,
+              window.toWall as WALLS_NAMES_TYPE,
+            ),
+            isFocused: isFocused(index),
+          };
+        }
+      });
     } else {
       return [];
     }
@@ -118,11 +119,12 @@ export const useWindowFields = (
     windowForm,
   ]);
 
-  if (windowForm && windowForm.windows) {
-    console.log(allWindow);
-    return {
-      balconies: allWindow.filter((balcony) => 'openLeft' in balcony),
-      windows: allWindow.filter((window) => !('openLeft' in window)),
-    };
-  } else return { windows: [], balconies: [] };
+  return {
+    balconies: allWindow.filter(
+      (balcony) => balcony.wall && 'openLeft' in balcony,
+    ),
+    windows: allWindow.filter(
+      (window) => window.wall && !('openLeft' in window),
+    ),
+  };
 };

--- a/src/components/Measurements/hooks/useWindowFields.tsx
+++ b/src/components/Measurements/hooks/useWindowFields.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { Control, useWatch, useFormState } from 'react-hook-form';
 import { useAppSelector } from '@/redux/hooks';
 import { selectFieldOnFocus } from '@/redux/slices/focusedFields-slice';
@@ -12,7 +12,7 @@ import {
 export const useWindowFields = (
   control: Control<SizesFormType>,
   invisible: boolean,
-): { windows: TWindow[]; balconies: TWindow[] } => {
+): TWindow[] => {
   const fieldOnFocus = useAppSelector(selectFieldOnFocus);
 
   const { errors } = useFormState({
@@ -56,9 +56,9 @@ export const useWindowFields = (
     [fieldOnFocus],
   );
 
-  const allWindow = useMemo(() => {
-    if (windowForm && windowForm.windows) {
-      return windowForm.windows.map((window, index) => {
+  if (windowForm?.type === 'window' && windowForm?.windows) {
+    return windowForm.windows
+      .map((window, index) => {
         if (window.doorSize) {
           return {
             wall: window.wallNumber as WALLS_NAMES_TYPE,
@@ -106,25 +106,10 @@ export const useWindowFields = (
             isFocused: isFocused(index),
           };
         }
-      });
-    } else {
-      return [];
-    }
-  }, [
-    distanceFromLeft,
-    distanceFromRight,
-    errors.windows?.windows,
-    invisible,
-    isFocused,
-    windowForm,
-  ]);
-
-  return {
-    balconies: allWindow.filter(
-      (balcony) => balcony.wall && 'openLeft' in balcony,
-    ),
-    windows: allWindow.filter(
-      (window) => window.wall && !('openLeft' in window),
-    ),
-  };
+      })
+      .filter((window) => window.wall)
+      .sort((a, b) => a.distance - b.distance);
+  } else {
+    return [];
+  }
 };

--- a/src/components/Measurements/hooks/useWindowFields.tsx
+++ b/src/components/Measurements/hooks/useWindowFields.tsx
@@ -63,7 +63,7 @@ export const useWindowFields = (
           return {
             wall: window.wallNumber as WALLS_NAMES_TYPE,
             size:
-              errors?.windows?.windows?.message ||
+              (errors?.windows?.windows?.message && index) ||
               errors.windows?.windows?.[index]?.size?.message ||
               errors.windows?.windows?.[index]?.doorSize?.message ||
               isInvisible
@@ -87,7 +87,7 @@ export const useWindowFields = (
           return {
             wall: window.wallNumber as WALLS_NAMES_TYPE,
             size:
-              errors?.windows?.windows?.message ||
+              (errors?.windows?.windows?.message && index) ||
               errors.windows?.windows?.[index]?.size?.message ||
               isInvisible
                 ? 0

--- a/src/components/Measurements/hooks/useWindowFields.tsx
+++ b/src/components/Measurements/hooks/useWindowFields.tsx
@@ -11,7 +11,7 @@ import {
 
 export const useWindowFields = (
   control: Control<SizesFormType>,
-  invisible: boolean,
+  isInvisible: boolean,
 ): TWindow[] => {
   const fieldOnFocus = useAppSelector(selectFieldOnFocus);
 
@@ -66,7 +66,7 @@ export const useWindowFields = (
               errors?.windows?.windows?.message ||
               errors.windows?.windows?.[index]?.size?.message ||
               errors.windows?.windows?.[index]?.doorSize?.message ||
-              invisible
+              isInvisible
                 ? 0
                 : Number(window.size) + Number(window.doorSize),
             distance: errors.windows?.windows?.[index]?.distanceToWall
@@ -89,7 +89,7 @@ export const useWindowFields = (
             size:
               errors?.windows?.windows?.message ||
               errors.windows?.windows?.[index]?.size?.message ||
-              invisible
+              isInvisible
                 ? 0
                 : Number(window.size),
             distance: errors.windows?.windows?.[index]?.distanceToWall

--- a/src/hooks/useFocusedObject.tsx
+++ b/src/hooks/useFocusedObject.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useCallback, useEffect, useState } from 'react';
+import { useAppDispatch } from '@/redux/hooks';
+import {
+  addBedroomFocusedField,
+  deleteBedroomFocusedField,
+} from '@/redux/slices/focusedFields-slice';
+
+export const useFocusedObject = (currentFieldName: string) => {
+  const dispatch = useAppDispatch();
+  const [isHovered, setHovered] = useState<boolean>(false);
+  const [isFocused, setFocused] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (isHovered || isFocused) {
+      dispatch(addBedroomFocusedField(currentFieldName));
+    } else {
+      dispatch(deleteBedroomFocusedField());
+    }
+  }, [dispatch, isFocused, currentFieldName, isHovered]);
+
+  const handleSetFocused = useCallback(
+    (val: boolean) => {
+      if (val !== isFocused) setFocused(val);
+    },
+    [isFocused],
+  );
+
+  const handleSetHovered = useCallback(
+    (val: boolean) => {
+      if (val !== isHovered) setHovered(val);
+    },
+    [isHovered],
+  );
+
+  return { handleSetFocused, handleSetHovered };
+};

--- a/src/mui/theme.ts
+++ b/src/mui/theme.ts
@@ -292,7 +292,7 @@ theme = createTheme(theme, {
             fontFamily: manrope.style.fontFamily,
             color: theme.palette.myGrey.grey300,
             opacity: 1,
-            fontSize: 18,
+            fontSize: 14,
             left: '50%',
             transform: 'translate(-50%, 16px) scale(1)',
           },
@@ -300,7 +300,7 @@ theme = createTheme(theme, {
         shrink: {
           '&.subvariant-grey': {
             left: '0',
-            transform: 'translate(0%, -20px) scale(0.75)',
+            transform: 'translate(0%, -20px) scale(0.96)',
           },
         },
       },


### PR DESCRIPTION
Добавлена отрисовка окон и балконов в общее изображение по данным step3:
- добавлен хук useWindowFields, который возвращает массив c окнами и балконами в компонент MeasurementsImage
- из компонента MeasurementsImage удалены кнопки, которые ранее меняли расположение окон/балкона, моковые данные

- добавлен общий хук useFocusedObject, который заменил повторяющийся код из Step2 и форм из Step3 (Window, WindowWithBalcony), который содержит 2 стейта с данными, находится ли интересующее нас поле в фокусе или в состоянии onHover, и если хотя бы одно из этих полей true, подставляет в fieldOnFocusSlice название этого поля. При этом вызов диспатча не происходит (профилактика ререндера), если значение не поменялось (у нас по несколько полей относятся к одной группе, чтобы диспатч не вызывался на фокус каждого из этих полей). Хук возвращает 2 коллбека, которые используются соответственно для фокуса или ховера.
- внутри WindowWithBalcony добавлен один stack для обертки и возможности одного onHover
- добавила onBlurHandler в TextFieldWrapper

- добавлен отдельный текст ошибки для проверки расстояния между окнами (когда сумма размеров не превышает размер стены)
- добавлена проверка расстояния между окнами без связи с общим размером объектов на данной стене
- изменена проверка общего размера, в случае, если пользователь устанавливает расстояние до окон от одной и той же стены

- подправлен цвет стрелок, когда объект (дверь, окно, балкон) не в фокусе (ранее серый - теперь трансперент)

деплой с нужным роутом: https://dizi-izi-frontend-lcndb9j1p-dizi-izi-frontend.vercel.app/room-measurements


![Снимок экрана 2024-11-24 162224](https://github.com/user-attachments/assets/fae68206-8978-420a-b115-89acc391d889)
![Снимок экрана 2024-11-24 162242](https://github.com/user-attachments/assets/e4722da1-cb05-4afa-b579-64ada56d4eca)
